### PR TITLE
move package to code.cloudfoundry.org/service-metrics

### DIFF
--- a/command_line_executor.go
+++ b/command_line_executor.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 
 	"code.cloudfoundry.org/lager"
-	"github.com/cloudfoundry/service-metrics/metrics"
+	"code.cloudfoundry.org/service-metrics/metrics"
 )
 
 // CommandLineExecutor implements metrics.Executor

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -18,7 +18,7 @@ func TestIntegration(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	srcPath := "github.com/cloudfoundry/service-metrics"
+	srcPath := "code.cloudfoundry.org/service-metrics"
 	var err error
 	execPath, err = gexec.Build(srcPath)
 	if err != nil {

--- a/metrics/egress_test.go
+++ b/metrics/egress_test.go
@@ -6,7 +6,7 @@ import (
 	loggregator "code.cloudfoundry.org/go-loggregator"
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 	"code.cloudfoundry.org/lager"
-	"github.com/cloudfoundry/service-metrics/metrics"
+	"code.cloudfoundry.org/service-metrics/metrics"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/metrics/processor_test.go
+++ b/metrics/processor_test.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/cloudfoundry/service-metrics/metrics"
+	"code.cloudfoundry.org/service-metrics/metrics"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/service-metrics.go
+++ b/service-metrics.go
@@ -8,8 +8,8 @@ import (
 
 	loggregator "code.cloudfoundry.org/go-loggregator"
 	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/service-metrics/metrics"
 	envstruct "github.com/cloudfoundry/go-envstruct"
-	"github.com/cloudfoundry/service-metrics/metrics"
 )
 
 type config struct {


### PR DESCRIPTION
This PR moves `github.com/cloudfoundry/service-metrics` to `code.cloudfoundry.org/service-metrics` to match other Cloud Foundry projects.

[Related BOSH release change](https://github.com/cloudfoundry/service-metrics-release/pull/1)